### PR TITLE
feat(audit): Ajouter les rapports d'audit des projets

### DIFF
--- a/Angular/mon-projet-angular/AUDIT_REPORT.md
+++ b/Angular/mon-projet-angular/AUDIT_REPORT.md
@@ -1,0 +1,47 @@
+# Rapport d'Audit - Projet "Mon Projet Angular"
+
+Ce document résume l'analyse du projet `mon-projet-angular` en termes de dépendances, de qualité de code et de bonnes pratiques.
+
+**Date de l'audit :** 2025-08-10
+
+## 1. Analyse des Dépendances (`package.json`)
+
+*   **Point Critique (Haute Priorité) :**
+    *   Les dépendances du projet sont sévèrement obsolètes. Le projet utilise Angular 8 (2019), alors que la version actuelle est bien plus récente.
+    *   `npm install` a révélé **123 vulnérabilités**, dont **18 critiques** et **53 élevées**. C'est un risque de sécurité majeur.
+    *   De nombreux paquets sont dépréciés, notamment `protractor` pour les tests e2e, qui n'est plus supporté.
+    *   **Recommandation :** Une migration vers une version récente d'Angular (16+) est indispensable pour corriger les failles de sécurité et bénéficier des nouvelles fonctionnalités. Cela implique de suivre le guide de migration officiel d'Angular (`ng update`).
+
+## 2. Qualité du Code et Architecture
+
+Le projet est une collection d'exercices et non une application cohérente. Le code est fonctionnel pour des démonstrations simples, mais il ne suit pas plusieurs bonnes pratiques essentielles d'Angular.
+
+### Problèmes Majeurs Identifiés
+
+1.  **Service non Injectable (`AppareilService`) :**
+    *   Le service `AppareilService` n'a pas le décorateur `@Injectable()`. Il n'est pas géré par le système d'injection de dépendances d'Angular, ce qui est une violation fondamentale des principes du framework.
+    *   **Recommandation :** Ajouter `@Injectable({ providedIn: 'root' })` au service.
+
+2.  **Mauvaise Gestion de l'État (`AppareilService`) :**
+    *   L'état de l'application (le tableau `tabAppareil`) est stocké dans un tableau public et mutable. N'importe quelle partie de l'application peut le modifier directement, ce qui conduit à un code imprévisible et difficile à déboguer.
+    *   **Recommandation :** Rendre le tableau d'état privé. Utiliser un `BehaviorSubject` pour stocker l'état et exposer un `Observable` (`.asObservable()`) pour que les composants s'y abonnent. Les méthodes du service devraient appeler `.next()` sur le `BehaviorSubject` pour émettre un nouvel état.
+
+### Problèmes Secondaires Identifiés
+
+1.  **Absence de Typage Fort :**
+    *   Le tableau d'appareils est de type `any[]`.
+    *   **Recommandation :** Créer une `interface` pour le modèle de données (ex: `Appareil`) et l'utiliser pour typer le tableau et les objets. `interface Appareil { name: string; status: 'allumé' | 'éteint'; }`.
+
+2.  **Code Mort et Commenté :**
+    *   Le template principal (`app.component.html`) contient une grande quantité de code commenté correspondant à d'anciens exercices.
+    *   **Recommandation :** Nettoyer le code et créer des routes et des composants distincts pour chaque exercice si l'objectif est de les conserver comme des démos séparées.
+
+3.  **Optimisation des Performances :**
+    *   Les composants n'utilisent pas la stratégie de détection de changement `OnPush`, ce qui peut entraîner des rendus inutiles.
+    *   **Recommandation :** Pour les composants dont les entrées sont immuables (ou des primitives), utiliser `changeDetection: ChangeDetectionStrategy.OnPush` pour améliorer les performances.
+
+## Conclusion de l'Audit
+
+Le projet est un bon exemple de bac à sable pour un débutant sur Angular. Cependant, pour en faire une base de projet saine, deux actions sont critiques :
+1.  **Mettre à jour les dépendances** en migrant vers une version récente d'Angular.
+2.  **Refactoriser la gestion de l'état** dans les services pour suivre les patrons de conception réactifs (Observables, Subjects) qui sont au cœur d'Angular.

--- a/JAVA EE/SpringEtORM/animoz/AUDIT_REPORT.md
+++ b/JAVA EE/SpringEtORM/animoz/AUDIT_REPORT.md
@@ -1,0 +1,49 @@
+# Rapport d'Audit - Projet "Animoz"
+
+Ce document résume l'analyse du projet "Animoz" en termes de dépendances, de qualité de code et de bugs potentiels.
+
+**Date de l'audit :** 2025-08-10
+
+## 1. Analyse des Dépendances (`pom.xml`)
+
+Le projet repose sur une stack technologique datant de 2019-2020, basée sur Java 8.
+
+*   **Point Critique (Haute Priorité) :**
+    *   `mysql-connector-java` est en version **5.1.47** (2018). Cette version est obsolète et n'est plus maintenue. Elle peut contenir des failles de sécurité connues.
+    *   **Recommandation :** Mettre à jour vers la dernière version du connecteur 8.x (`8.0.33` ou plus récent) et ajuster la configuration de la source de données (le nom de la classe du driver change).
+
+*   **Points Mineurs (Basse Priorité) :**
+    *   Les versions de Spring (5.2.1), Hibernate (5.4.24), et JasperReports (6.12.2) sont anciennes mais fonctionnelles pour un projet de cette nature. Une mise à jour majeure nécessiterait une migration vers Java 17+ et Spring 6, ce qui est un effort conséquent.
+    *   **Recommandation :** Pour une modernisation future, envisager une migration complète de la stack. Pour l'instant, le focus doit être sur le connecteur MySQL.
+
+## 2. Qualité du Code et Architecture
+
+L'application suit une structure MVC classique (Contrôleur, Service, DAO), ce qui est une bonne pratique. Cependant, plusieurs points peuvent être améliorés.
+
+### Problèmes Identifiés
+
+1.  **Violation de la Séparation des Couches :** Le `AnimalControleur` accède directement à la `DataSource` et gère la connexion SQL pour la génération de rapports.
+    *   **Recommandation :** Déplacer la logique de génération de rapports (y compris l'accès aux données) dans une classe de service dédiée (ex: `RapportService`). Le contrôleur ne devrait qu'appeler ce service.
+
+2.  **Gestion des Erreurs Insuffisante :**
+    *   Les blocs `catch` dans la génération de rapports se contentent d'un `e.printStackTrace()`, ce qui ne produit aucune réponse claire pour l'utilisateur en cas d'échec.
+    *   Les erreurs de validation sont signalées par `System.out.println()`.
+    *   **Recommandation :** Mettre en place un framework de logging (ex: SLF4J/Logback). Gérer les exceptions dans les contrôleurs (via `@ExceptionHandler` ou un `ControllerAdvice`) pour retourner des messages d'erreur appropriés à l'utilisateur.
+
+3.  **Utilisation Incohérente des DTOs :** La méthode d'ajout utilise un `AnimalDto` (bien), mais la méthode de modification utilise directement l'entité `Animal`.
+    *   **Recommandation :** Utiliser systématiquement les DTOs pour toutes les données entrantes de la couche de présentation afin d'éviter les vulnérabilités de "mass assignment" et de découpler le modèle de la vue.
+
+4.  **Logique Métier dans le Contrôleur :** Des détails comme le nom de l'auteur du rapport (`"Kénan Roux"`) sont codés en dur dans le contrôleur.
+    *   **Recommandation :** Externaliser les valeurs de configuration dans un fichier de propriétés (`application.properties`).
+
+## 3. Bugs Potentiels et Comportements Anormaux
+
+1.  **Échec Silencieux à l'Ajout :** Si on tente d'ajouter un animal qui existe déjà (même nom), l'opération échoue silencieusement dans la couche service, et l'utilisateur est redirigé comme si tout avait fonctionné.
+    *   **Recommandation :** Le `AnimalService` devrait lancer une exception métier (ex: `AnimalAlreadyExistsException`). Le contrôleur devrait intercepter cette exception et afficher un message d'erreur à l'utilisateur sur le formulaire.
+
+2.  **Réponse Corrompue en cas d'Erreur de Rapport :** Si la génération du PDF échoue, le flux de sortie (`OutputStream`) sera probablement corrompu ou vide, résultant en une erreur de téléchargement ou un fichier PDF invalide pour l'utilisateur.
+    *   **Recommandation :** Implémenter une gestion d'erreur robuste qui retourne une page d'erreur HTML ou un statut HTTP approprié.
+
+## Conclusion de l'Audit
+
+Le projet est une bonne démonstration d'une application Spring MVC de base. Les points critiques à corriger concernent la **mise à jour du connecteur MySQL** et l'**amélioration de la gestion des erreurs**. Les autres points sont des recommandations pour aligner le code avec les meilleures pratiques modernes et le rendre plus robuste et maintenable.

--- a/Symfony/mon-projet/AUDIT_REPORT.md
+++ b/Symfony/mon-projet/AUDIT_REPORT.md
@@ -1,0 +1,34 @@
+# Rapport d'Audit - Projet "Symfony/mon-projet"
+
+Ce document résume l'analyse du projet `mon-projet` en termes de dépendances, de qualité de code et de bonnes pratiques.
+
+**Date de l'audit :** 2025-08-10
+
+## 1. Analyse des Dépendances (`composer.json`)
+
+*   **Point Critique (Haute Priorité) :**
+    *   Le projet utilise **Symfony 5.0**, une version qui n'est plus maintenue. Les mises à jour de sécurité pour la branche Symfony 5.x ont pris fin en novembre 2023. L'utilisation de cette version représente un risque de sécurité.
+    *   La version de PHP requise (`^7.2.5`) est également obsolète et n'est plus supportée.
+    *   **Recommandation :** Mettre à jour le projet vers une version maintenue de Symfony (6.4 LTS ou 7.x) et une version de PHP supportée (8.2+). Cela nécessitera de revoir le code pour s'adapter aux changements de l'API de Symfony.
+
+## 2. Qualité du Code et Architecture
+
+Le projet est un squelette d'application Symfony très basique, de type "Hello World". Il ne contient pas de logique métier complexe, mais quelques points sont à noter.
+
+### Problèmes Identifiés
+
+1.  **Utilisation de `die()` dans un Contrôleur :**
+    *   La méthode `index()` dans `DefaultController` utilise `die()`. Cette fonction arrête brutalement l'exécution du script et court-circuite le noyau Symfony et le cycle de vie de la réponse HTTP.
+    *   **Recommandation :** Toujours retourner un objet `Symfony\Component\HttpFoundation\Response`.
+
+2.  **HTML en dur dans le Contrôleur :**
+    *   La méthode `home()` retourne une `Response` avec du HTML codé en dur. Bien que fonctionnel, cela va à l'encontre du principe de séparation des préoccupations.
+    *   **Recommandation :** Utiliser le moteur de templates Twig (qui est déjà installé) pour rendre les vues. Le contrôleur devrait appeler `$this->render('default/home.html.twig', [...])`.
+
+3.  **Projet Incomplet :**
+    *   Le projet est un simple point de départ. Il manque toutes les couches d'une application réelle : pas de modèle de données (Doctrine), pas de services, pas de formulaires, etc.
+    *   **Recommandation :** Ce projet peut servir de base pour un développement futur, mais il n'est pas représentatif d'une application complète.
+
+## Conclusion de l'Audit
+
+Le projet est un bon exemple pour démarrer avec Symfony, mais il est dans un état trop embryonnaire pour être considéré comme une application. Le point le plus critique est l'**obsolescence de la version de Symfony et de PHP**, qui pose un risque de sécurité. Les problèmes de qualité de code sont mineurs étant donné la simplicité du projet, mais ils indiquent des pratiques à ne pas suivre dans un projet de production.


### PR DESCRIPTION
Création de rapports d'audit pour les trois projets principaux afin d'évaluer leur état et de proposer des pistes d'amélioration.

- **Projet 'Animoz' (Java/Spring) :** L'audit a révélé des dépendances critiques obsolètes (connecteur MySQL) et des améliorations possibles dans la gestion des erreurs et la séparation des couches.

- **Projet 'mon-projet-angular' (Angular) :** L'audit a identifié un très grand nombre de vulnérabilités dues à des dépendances sévèrement obsolètes (Angular 8). Le code présente également des lacunes importantes en matière de bonnes pratiques (gestion de l'état, typage).

- **Projet 'mon-projet' (Symfony) :** L'audit a montré que le projet utilise une version de Symfony qui n'est plus maintenue, ce qui représente un risque de sécurité. Le code, bien que simple, contient des anti-patterns.

Chaque rapport fournit des recommandations spécifiques pour la modernisation et la correction des problèmes identifiés.